### PR TITLE
Fix invalid "sequence" parameter in dynamic content example

### DIFF
--- a/content/pages/dynamic-content.md
+++ b/content/pages/dynamic-content.md
@@ -28,17 +28,16 @@ namespace BlazorPages.Pages
     {
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            var seq = 0;
-            builder.OpenElement(seq, "table");
-            builder.OpenElement(++seq, "tbody");
+            builder.OpenElement(0, "table");
+            builder.OpenElement(1, "tbody");
 
             for (var row = 0; row < 3; row++)
             {
-                builder.OpenElement(++seq, "tr");
+                builder.OpenElement(2, "tr");
                 for (var col = 0; col < 3; col++)
                 {
-                    builder.OpenElement(++seq, "td");
-                    builder.AddAttribute(++seq, "class", "tictactoe-cell");
+                    builder.OpenElement(3, "td");
+                    builder.AddAttribute(4, "class", "tictactoe-cell");
                     builder.CloseElement();
                 }
 

--- a/samples/BlazorPages/Pages/DynamicRenderTree.cs
+++ b/samples/BlazorPages/Pages/DynamicRenderTree.cs
@@ -8,17 +8,16 @@ namespace BlazorPages.Pages
     {
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
-            var seq = 0;
-            builder.OpenElement(seq, "table");
-            builder.OpenElement(++seq, "tbody");
+            builder.OpenElement(0, "table");
+            builder.OpenElement(1, "tbody");
 
             for (var row = 0; row < 3; row++)
             {
-                builder.OpenElement(++seq, "tr");
+                builder.OpenElement(2, "tr");
                 for (var col = 0; col < 3; col++)
                 {
-                    builder.OpenElement(++seq, "td");
-                    builder.AddAttribute(++seq, "class", "tictactoe-cell");
+                    builder.OpenElement(3, "td");
+                    builder.AddAttribute(4, "class", "tictactoe-cell");
                     builder.CloseElement();
                 }
 


### PR DESCRIPTION
While it doesn't matter in this particular example since row and column count doesn't change, it might cause issues when generating more dynamic content